### PR TITLE
Add baseline hazard helpers

### DIFF
--- a/R/baseline_exponential.R
+++ b/R/baseline_exponential.R
@@ -1,0 +1,64 @@
+#' Exponential baseline hazard and derivatives
+#'
+#' Functions related to a parametric survival model with an exponential
+#' baseline hazard. Parameter vector is `params = c(rate)` with rate > 0.
+#'
+#' @param t Numeric vector of times.
+#' @param params Numeric vector of length 1 giving the rate.
+#'
+#' @return `h0_exponential` and `H0_exponential` return numeric vectors of
+#'   hazard and cumulative hazard values, respectively.
+#' @examples
+#' h0_exponential(1:3, 0.5)
+#' @export
+h0_exponential <- function(t, params) {
+  rate <- params[1]
+  rep(rate, length(t))
+}
+
+#' @rdname h0_exponential
+#' @export
+H0_exponential <- function(t, params) {
+  rate <- params[1]
+  rate * t
+}
+
+#' Log-likelihood for exponential baseline
+#'
+#' Computes the log-likelihood for independent survival times with an
+#' exponential baseline hazard.
+#'
+#' @param params Numeric vector `c(rate)` with rate > 0.
+#' @param times Follow-up times.
+#' @param event Event indicators (1 = event, 0 = censored).
+#'
+#' @return Numeric scalar log-likelihood.
+#' @export
+loglik_exponential <- function(params, times, event) {
+  rate <- params[1]
+  if (rate <= 0) return(-Inf)
+  sum(event * log(rate) - rate * times)
+}
+
+#' Score vector for exponential baseline
+#'
+#' @inheritParams loglik_exponential
+#'
+#' @return Numeric vector of length 1 with the score.
+#' @export
+score_exponential <- function(params, times, event) {
+  rate <- params[1]
+  c(sum(event / rate - times))
+}
+
+#' Hessian matrix for exponential baseline
+#'
+#' @inheritParams loglik_exponential
+#'
+#' @return `1 x 1` numeric matrix with the second derivative of the
+#'   log-likelihood.
+#' @export
+hessian_exponential <- function(params, times, event) {
+  rate <- params[1]
+  matrix(-sum(event) / rate^2, nrow = 1, ncol = 1)
+}

--- a/R/baseline_lognormal.R
+++ b/R/baseline_lognormal.R
@@ -1,0 +1,74 @@
+#' Log-normal baseline hazard and derivatives
+#'
+#' Hazard-related functions for a log-normal baseline distribution. Parameter
+#' vector is `params = c(meanlog, sdlog)` where `sdlog > 0`.
+#'
+#' @param t Numeric vector of times.
+#' @param params Numeric vector `c(meanlog, sdlog)`.
+#'
+#' @return `h0_lognormal` and `H0_lognormal` return numeric vectors of hazard and
+#'   cumulative hazard values.
+#' @examples
+#' h0_lognormal(1:3, c(0, 1))
+#' @export
+h0_lognormal <- function(t, params) {
+  meanlog <- params[1]
+  sdlog <- params[2]
+  dlnorm(t, meanlog = meanlog, sdlog = sdlog) /
+    (1 - plnorm(t, meanlog = meanlog, sdlog = sdlog))
+}
+
+#' @rdname h0_lognormal
+#' @export
+H0_lognormal <- function(t, params) {
+  meanlog <- params[1]
+  sdlog <- params[2]
+  -log(1 - plnorm(t, meanlog = meanlog, sdlog = sdlog))
+}
+
+#' Log-likelihood for log-normal baseline
+#'
+#' @param params Numeric vector `c(meanlog, sdlog)`.
+#' @param times Follow-up times.
+#' @param event Event indicators (1 = event, 0 = censored).
+#'
+#' @return Numeric scalar log-likelihood.
+#' @export
+loglik_lognormal <- function(params, times, event) {
+  meanlog <- params[1]
+  sdlog <- params[2]
+  if (sdlog <= 0) return(-Inf)
+  h <- h0_lognormal(times, params)
+  H <- H0_lognormal(times, params)
+  sum(event * log(h) - H)
+}
+
+#' Score vector for log-normal baseline
+#'
+#' Numerical gradient of the log-likelihood with respect to the parameters.
+#'
+#' @inheritParams loglik_lognormal
+#'
+#' @return Numeric vector of length two.
+#' @export
+score_lognormal <- function(params, times, event) {
+  if (!requireNamespace("numDeriv", quietly = TRUE)) {
+    stop("Package 'numDeriv' is required for score_lognormal")
+  }
+  numDeriv::grad(loglik_lognormal, params, times = times, event = event)
+}
+
+#' Hessian matrix for log-normal baseline
+#'
+#' Numerical Hessian of the log-likelihood with respect to the parameters.
+#'
+#' @inheritParams loglik_lognormal
+#'
+#' @return `2 x 2` numeric matrix.
+#' @export
+hessian_lognormal <- function(params, times, event) {
+  if (!requireNamespace("numDeriv", quietly = TRUE)) {
+    stop("Package 'numDeriv' is required for hessian_lognormal")
+  }
+  numDeriv::hessian(loglik_lognormal, params, times = times, event = event)
+}

--- a/R/baseline_piecewise_exp.R
+++ b/R/baseline_piecewise_exp.R
@@ -1,0 +1,77 @@
+#' Piecewise exponential baseline hazard and derivatives
+#'
+#' Functions for a piecewise constant baseline hazard. Parameters are the vector
+#' of rates for each interval defined by `breaks`.
+#'
+#' @param t Numeric vector of times.
+#' @param breaks Increasing numeric vector of interval boundaries of length
+#'   `length(rates) + 1`.
+#' @param rates Numeric vector of interval rates.
+#'
+#' @return `h0_piecewise_exp` and `H0_piecewise_exp` return numeric vectors of
+#'   hazard and cumulative hazard values.
+#' @examples
+#' h0_piecewise_exp(c(1, 3, 6), c(0, 2, 5, 10), c(0.5, 1, 0.2))
+#' @export
+h0_piecewise_exp <- function(t, breaks, rates) {
+  rates[findInterval(t, breaks, rightmost.closed = TRUE)]
+}
+
+#' @rdname h0_piecewise_exp
+#' @export
+H0_piecewise_exp <- function(t, breaks, rates) {
+  sapply(t, function(x) {
+    idx <- findInterval(x, breaks, rightmost.closed = TRUE)
+    if (idx == 0) return(0)
+    cum <- sum(rates[seq_len(idx - 1)] * diff(breaks[seq_len(idx)]))
+    cum + rates[idx] * (x - breaks[idx])
+  })
+}
+
+#' Log-likelihood for piecewise exponential baseline
+#'
+#' @param rates Numeric vector of interval rates.
+#' @param times Follow-up times.
+#' @param event Event indicators (1 = event, 0 = censored).
+#' @param breaks Increasing numeric vector of interval boundaries.
+#'
+#' @return Numeric scalar log-likelihood.
+#' @export
+loglik_piecewise_exp <- function(rates, times, event, breaks) {
+  if (any(rates <= 0)) return(-Inf)
+  interval <- findInterval(times, breaks, rightmost.closed = TRUE)
+  exposure <- sapply(seq_along(rates), function(k) {
+    pmax(pmin(times, breaks[k + 1]) - breaks[k], 0)
+  })
+  event_counts <- tabulate(interval[event == 1], nbins = length(rates))
+  E_k <- colSums(exposure)
+  sum(event_counts * log(rates) - rates * E_k)
+}
+
+#' Score vector for piecewise exponential baseline
+#'
+#' @inheritParams loglik_piecewise_exp
+#'
+#' @return Numeric vector of scores for each rate.
+#' @export
+score_piecewise_exp <- function(rates, times, event, breaks) {
+  interval <- findInterval(times, breaks, rightmost.closed = TRUE)
+  exposure <- sapply(seq_along(rates), function(k) {
+    pmax(pmin(times, breaks[k + 1]) - breaks[k], 0)
+  })
+  event_counts <- tabulate(interval[event == 1], nbins = length(rates))
+  E_k <- colSums(exposure)
+  event_counts / rates - E_k
+}
+
+#' Hessian matrix for piecewise exponential baseline
+#'
+#' @inheritParams loglik_piecewise_exp
+#'
+#' @return Diagonal matrix with second derivatives of the log-likelihood.
+#' @export
+hessian_piecewise_exp <- function(rates, times, event, breaks) {
+  interval <- findInterval(times, breaks, rightmost.closed = TRUE)
+  event_counts <- tabulate(interval[event == 1], nbins = length(rates))
+  diag(-event_counts / rates^2)
+}

--- a/R/baseline_weibull.R
+++ b/R/baseline_weibull.R
@@ -1,0 +1,81 @@
+#' Weibull baseline hazard and derivatives
+#'
+#' Provides hazard, cumulative hazard, log-likelihood, score, and Hessian for
+#' a Weibull baseline hazard. Parameter vector is `params = c(shape, scale)`
+#' with both parameters > 0.
+#'
+#' @param t Numeric vector of times.
+#' @param params Numeric vector `c(shape, scale)`.
+#'
+#' @return `h0_weibull` and `H0_weibull` return numeric vectors with hazard and
+#'   cumulative hazard values.
+#' @examples
+#' h0_weibull(1:3, c(2, 1))
+#' @export
+h0_weibull <- function(t, params) {
+  shape <- params[1]
+  scale <- params[2]
+  shape / scale * (t / scale)^(shape - 1)
+}
+
+#' @rdname h0_weibull
+#' @export
+H0_weibull <- function(t, params) {
+  shape <- params[1]
+  scale <- params[2]
+  (t / scale)^shape
+}
+
+#' Log-likelihood for Weibull baseline
+#'
+#' @param params Numeric vector `c(shape, scale)`.
+#' @param times Follow-up times.
+#' @param event Event indicators (1 = event, 0 = censored).
+#'
+#' @return Numeric scalar log-likelihood.
+#' @export
+loglik_weibull <- function(params, times, event) {
+  shape <- params[1]
+  scale <- params[2]
+  if (any(params <= 0)) return(-Inf)
+  h <- h0_weibull(times, params)
+  H <- H0_weibull(times, params)
+  sum(event * log(h) - H)
+}
+
+#' Score vector for Weibull baseline
+#'
+#' @inheritParams loglik_weibull
+#'
+#' @return Numeric vector of length two containing the score for `shape` and
+#'   `scale`.
+#' @export
+score_weibull <- function(params, times, event) {
+  shape <- params[1]
+  scale <- params[2]
+  z <- times / scale
+  log_z <- log(z)
+  H <- z^shape
+  s1 <- sum(event * (1 / shape + log_z) - H * log_z)
+  s2 <- sum((shape / scale) * (H - event))
+  c(s1, s2)
+}
+
+#' Hessian matrix for Weibull baseline
+#'
+#' @inheritParams loglik_weibull
+#'
+#' @return `2 x 2` numeric matrix with second derivatives of the
+#'   log-likelihood.
+#' @export
+hessian_weibull <- function(params, times, event) {
+  shape <- params[1]
+  scale <- params[2]
+  z <- times / scale
+  log_z <- log(z)
+  H <- z^shape
+  h11 <- sum(-event / shape^2 - H * log_z^2)
+  h12 <- sum(-event / scale + H * (shape * log_z + 1) / scale)
+  h22 <- sum((shape / scale^2) * (event - (1 + shape) * H))
+  matrix(c(h11, h12, h12, h22), nrow = 2, byrow = TRUE)
+}


### PR DESCRIPTION
## Summary
- add exponential baseline hazard helpers
- add Weibull baseline hazard helpers
- add log-normal baseline hazard helpers
- add piecewise exponential baseline hazard helpers

## Testing
- `R -q -e "testthat::test_dir('tests/')"` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6892712f3d14832d98536b1b18c116f2