### PR TITLE
Add coverage utilities for simulation study

### DIFF
--- a/R/coverage_multiN.R
+++ b/R/coverage_multiN.R
@@ -1,0 +1,50 @@
+#' Coverage summary across sample sizes
+#'
+#' Runs `coverage_prob()` for a vector of sample sizes and summarises the
+#' resulting coverage probabilities and average confidence interval widths.
+#'
+#' @param baseline Baseline hazard specification (character string or list).
+#' @param true_params List with true parameter values.
+#' @param n_vec Integer vector of sample sizes to evaluate.
+#' @param sims Number of simulations per sample size.
+#' @param alpha Significance level for two-sided confidence intervals.
+#' @param X_fun Optional function generating covariate matrices.
+#' @param save_path Optional file path to save aggregated results via `saveRDS`.
+#'
+#' @return A list with elements
+#'   - `coverage`: data frame with columns `N`, `Parameter`, and `Coverage`.
+#'   - `ci_width`: data frame with columns `N`, `Parameter`, and `MeanWidth`.
+#'   If `save_path` is supplied the list is saved to disk.
+#' @export
+coverage_multiN <- function(baseline, true_params, n_vec, sims, alpha = 0.05,
+                            X_fun = NULL, save_path = NULL) {
+  cov_records <- list()
+  width_records <- list()
+  for (n in n_vec) {
+    res <- coverage_prob(baseline, true_params, n, sims, alpha = alpha,
+                         X_fun = X_fun)
+    cov_vec <- res$coverage
+    cov_records[[length(cov_records) + 1]] <- data.frame(
+      N = n,
+      Parameter = names(cov_vec),
+      Coverage = as.numeric(cov_vec)
+    )
+    ci_df <- res$ci_data
+    if (is.null(ci_df) || nrow(ci_df) == 0) {
+      width_summary <- data.frame(Parameter = names(cov_vec), Width = NA_real_)
+    } else {
+      ci_df$Width <- ci_df$Upper - ci_df$Lower
+      width_summary <- aggregate(Width ~ Parameter, data = ci_df, FUN = mean)
+    }
+    width_records[[length(width_records) + 1]] <- data.frame(
+      N = n,
+      Parameter = width_summary$Parameter,
+      MeanWidth = width_summary$Width
+    )
+  }
+  coverage_df <- do.call(rbind, cov_records)
+  width_df <- do.call(rbind, width_records)
+  result <- list(coverage = coverage_df, ci_width = width_df)
+  if (!is.null(save_path)) saveRDS(result, save_path)
+  result
+}

--- a/R/coverage_simple.R
+++ b/R/coverage_simple.R
@@ -1,0 +1,85 @@
+#' Empirical coverage for frailty model parameters
+#'
+#' Simulates datasets from a gamma frailty model and fits the model to
+#' estimate empirical coverage probabilities for nominal confidence
+#' intervals.
+#'
+#' @param baseline Baseline hazard specification (character string or list).
+#' @param true_params List with elements `baseline`, `beta`, `frailty_var`,
+#'   and optionally `censor_rate`.
+#' @param n Number of observations in each simulation.
+#' @param sims Number of Monte Carlo replications.
+#' @param alpha Significance level for two-sided confidence intervals.
+#' @param X_fun Optional function generating an `n x p` covariate matrix;
+#'   defaults to standard normal covariates where `p` is the length of
+#'   `true_params$beta`.
+#' @param save_path Optional file path to save results via `saveRDS`.
+#'
+#' @return A list with elements
+#'   - `coverage`: named numeric vector of empirical coverage probabilities.
+#'   - `ci_data`: data frame of confidence interval results across simulations.
+#'   If `save_path` is provided, the list is saved to disk.
+#' @export
+coverage_prob <- function(baseline, true_params, n, sims, alpha = 0.05,
+                          X_fun = NULL, save_path = NULL) {
+  beta <- true_params$beta
+  if (is.null(beta)) beta <- numeric()
+  p <- length(beta)
+  X_gen <- function(n) {
+    if (is.null(X_fun)) {
+      if (p > 0) matrix(rnorm(n * p), nrow = n, ncol = p) else matrix(nrow = n, ncol = 0)
+    } else {
+      X <- X_fun(n)
+      if (!is.matrix(X) || nrow(X) != n || ncol(X) != p) {
+        stop("X_fun must return an n x p matrix")
+      }
+      X
+    }
+  }
+  base_names <- names(true_params$baseline)
+  if (is.null(base_names)) base_names <- paste0("baseline_", seq_along(true_params$baseline))
+  beta_names <- if (p > 0) paste0("beta_", seq_len(p)) else character(0)
+  param_names <- c(base_names, beta_names, "frailty_var")
+  n_par <- length(param_names)
+  coverage_mat <- matrix(NA, nrow = sims, ncol = n_par)
+  colnames(coverage_mat) <- param_names
+  ci_records <- vector("list", sims)
+  true_vals <- c(true_params$baseline, beta, true_params$frailty_var)
+  names(true_vals) <- param_names
+  for (i in seq_len(sims)) {
+    X <- X_gen(n)
+    sim <- simulate_frailty_data(baseline, n, params = true_params, X = X)
+    params_init <- true_params
+    params_init$censor_rate <- NULL
+    fit <- try(estimate_frailty_mle(params_init, sim$time, sim$event, X, baseline),
+               silent = TRUE)
+    if (inherits(fit, "try-error")) next
+    est_base <- fit$estimates$baseline
+    est_beta <- fit$estimates$beta
+    est_theta <- fit$estimates$frailty_var
+    se_base <- fit$se$baseline
+    se_beta <- fit$se$beta
+    se_theta <- fit$se$frailty_var
+    est <- c(est_base, est_beta, est_theta)
+    se <- c(se_base, se_beta, se_theta)
+    names(est) <- param_names
+    z <- qnorm(1 - alpha / 2)
+    lower <- est - z * se
+    upper <- est + z * se
+    coverage_mat[i, ] <- (true_vals >= lower) & (true_vals <= upper)
+    ci_records[[i]] <- data.frame(
+      Parameter = param_names,
+      Lower = lower,
+      Estimate = est,
+      Upper = upper,
+      True = true_vals,
+      Sim = i
+    )
+  }
+  keep <- complete.cases(coverage_mat)
+  coverage <- colMeans(coverage_mat[keep, , drop = FALSE])
+  ci_all <- do.call(rbind, ci_records[keep])
+  res <- list(coverage = coverage, ci_data = ci_all)
+  if (!is.null(save_path)) saveRDS(res, save_path)
+  res
+}


### PR DESCRIPTION
## Summary
- add `coverage_prob` for empirical coverage computation with optional result saving
- add `coverage_multiN` to summarise coverage and CI widths over sample sizes

## Testing
- `pytest`
- `R -q -e "testthat::test_dir('tests/')"` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689276389448832d84aa0e75ab8f3b1b