### PR TITLE
Add roxygen examples for R utilities

### DIFF
--- a/R/coverage_multiN.R
+++ b/R/coverage_multiN.R
@@ -15,6 +15,9 @@
 #'   - `coverage`: data frame with columns `N`, `Parameter`, and `Coverage`.
 #'   - `ci_width`: data frame with columns `N`, `Parameter`, and `MeanWidth`.
 #'   If `save_path` is supplied the list is saved to disk.
+#' @examples
+#' params <- list(baseline = 0.1, beta = 0.5, frailty_var = 0.2)
+#' coverage_multiN("exponential", params, n_vec = c(50, 100), sims = 2)
 #' @export
 coverage_multiN <- function(baseline, true_params, n_vec, sims, alpha = 0.05,
                             X_fun = NULL, save_path = NULL) {

--- a/R/coverage_simple.R
+++ b/R/coverage_simple.R
@@ -19,6 +19,9 @@
 #'   - `coverage`: named numeric vector of empirical coverage probabilities.
 #'   - `ci_data`: data frame of confidence interval results across simulations.
 #'   If `save_path` is provided, the list is saved to disk.
+#' @examples
+#' params <- list(baseline = 0.1, beta = 0.5, frailty_var = 0.2)
+#' coverage_prob("exponential", params, n = 50, sims = 2)
 #' @export
 coverage_prob <- function(baseline, true_params, n, sims, alpha = 0.05,
                           X_fun = NULL, save_path = NULL) {

--- a/R/estimate_frailty_mle.R
+++ b/R/estimate_frailty_mle.R
@@ -12,8 +12,14 @@
 #' @param event Event indicators (1 = event, 0 = censored).
 #' @param X Matrix of covariates with rows equal to length of `times`.
 #' @param baseline Baseline specification (see `simulate_frailty_data`).
-#'
+#' 
 #' @return A list with estimated parameters, standard errors, and log-likelihood.
+#' @examples
+#' init <- list(baseline = 0.1, beta = 0, frailty_var = 0.5)
+#' times <- c(1, 2, 3)
+#' event <- c(1, 0, 1)
+#' X <- matrix(numeric(), nrow = 3, ncol = 0)
+#' estimate_frailty_mle(init, times, event, X, "exponential")
 #' @export
 estimate_frailty_mle <- function(params_init, times, event, X, baseline) {
   resolve_baseline <- function(baseline) {

--- a/R/simulate_frailty.R
+++ b/R/simulate_frailty.R
@@ -17,6 +17,10 @@
 #' @param X Matrix of covariates with `n` rows.
 #'
 #' @return A list with components `time` and `event`.
+#' @examples
+#' params <- list(baseline = 0.1, beta = 0.5, frailty_var = 0.2)
+#' X <- matrix(rnorm(20), ncol = 1)
+#' simulate_frailty_data("exponential", n = 20, params = params, X = X)
 #' @export
 simulate_frailty_data <- function(baseline, n, params, X) {
   resolve_baseline <- function(baseline) {

--- a/initialScript.R
+++ b/initialScript.R
@@ -1,3 +1,14 @@
+#' Flexible frailty model utilities
+#'
+#' Helper functions for fitting a frailty model with customizable baseline
+#' hazards and empirical Bayes estimation.
+#'
+#' @examples
+#' \dontrun{
+#' # Script depends on external data; see functions below for usage
+#' }
+NULL
+
 # Flexible frailty model with customizable baseline hazard (H0) and EB frailty estimation (with covariate integration)
 
 dist_chosen <- "weibull"  # Options: "weibull", "exponential", "gompertz", "gamma", "lognormal", "loglogistic", "piecewise_exp"
@@ -50,6 +61,24 @@ baseline_functions <- list(
   )
 )
 
+#' Log-likelihood for flexible frailty model
+#'
+#' Computes the negative log-likelihood for a frailty model with
+#' distribution-specific baselines and covariate effects.
+#'
+#' @param params Parameter vector containing baseline, frailty variance,
+#'   and covariate effects.
+#' @param times Follow-up times.
+#' @param event Event indicators.
+#' @param X Covariate matrix.
+#' @param dist Baseline distribution name.
+#' @param breaks Break points for piecewise exponential baseline.
+#'
+#' @return Numeric scalar negative log-likelihood.
+#' @examples
+#' \dontrun{
+#' frailty_flexible_loglik(rep(0.1, 5), surv_time, event, X_real)
+#' }
 frailty_flexible_loglik <- function(params, times, event, X, dist=dist_chosen, breaks=breaks_pw){
   frailty_var <- params[3]
   p <- ncol(X)
@@ -98,6 +127,18 @@ frailty_flexible_loglik <- function(params, times, event, X, dist=dist_chosen, b
   -sum(event*(log(h)+log(S))+(1-event)*log(S))
 }
 
+#' Empirical Bayes frailty estimate
+#'
+#' Computes the posterior mean frailty for each observation under the
+#' specified baseline hazard and covariate effects.
+#'
+#' @inheritParams frailty_flexible_loglik
+#'
+#' @return Numeric vector of expected frailty values.
+#' @examples
+#' \dontrun{
+#' EB_frailty_flexible(rep(0.1, 5), surv_time, event, X_real)
+#' }
 EB_frailty_flexible <- function(params, times, event, X, dist=dist_chosen, breaks=breaks_pw){
   frailty_var <- params[3]
   alpha_gamma <- 1/frailty_var


### PR DESCRIPTION
## Summary
- add roxygen example sections to coverage summaries and simulation helpers
- document flexible frailty script functions with roxygen headers

## Testing
- `R -q -e 'roxygen2::roxygenise()'` *(fails: there is no package called 'roxygen2')*


------
https://chatgpt.com/codex/tasks/task_e_68927ad29184832d9df6a78aa74f8393