### PR TITLE
Add workflow examples to roxygen docs

### DIFF
--- a/R/estimate_frailty_mle.R
+++ b/R/estimate_frailty_mle.R
@@ -15,11 +15,15 @@
 #' 
 #' @return A list with estimated parameters, standard errors, and log-likelihood.
 #' @examples
-#' init <- list(baseline = 0.1, beta = 0, frailty_var = 0.5)
-#' times <- c(1, 2, 3)
-#' event <- c(1, 0, 1)
-#' X <- matrix(numeric(), nrow = 3, ncol = 0)
-#' estimate_frailty_mle(init, times, event, X, "exponential")
+#' params <- list(baseline = 0.1, beta = 0.5, frailty_var = 0.2)
+#' X <- matrix(rnorm(20), ncol = 1)
+#' sim <- simulate_frailty_data("exponential", n = 20, params = params, X = X)
+#' init <- list(baseline = 0.1, beta = 0, frailty_var = 0.2)
+#' fit <- estimate_frailty_mle(init, sim$time, sim$event, X, "exponential")
+#' \dontrun{
+#' frailty_simulation_pipeline("exponential", sims = 2, n = c(20, 40),
+#'                             true_params = params, plot = FALSE)
+#' }
 #' @export
 estimate_frailty_mle <- function(params_init, times, event, X, baseline) {
   resolve_baseline <- function(baseline) {

--- a/R/frailty_simulation_pipeline.R
+++ b/R/frailty_simulation_pipeline.R
@@ -22,8 +22,15 @@
 #'
 #' @examples
 #' params <- list(baseline = 0.1, beta = 0.5, frailty_var = 0.2)
-#' frailty_simulation_pipeline("exponential", sims = 10, n = c(200, 400),
+#' X <- matrix(rnorm(20), ncol = 1)
+#' sim <- simulate_frailty_data("exponential", n = 20, params = params, X = X)
+#' fit <- estimate_frailty_mle(list(baseline = 0.1, beta = 0,
+#'                                  frailty_var = 0.2),
+#'                             sim$time, sim$event, X, "exponential")
+#' \dontrun{
+#' frailty_simulation_pipeline("exponential", sims = 2, n = c(20, 40),
 #'                             true_params = params, plot = FALSE)
+#' }
 #' @export
 frailty_simulation_pipeline <- function(baseline, sims, n, true_params, plot = TRUE) {
   `%||%` <- function(a, b) if (!is.null(a)) a else b

--- a/R/simulate_frailty.R
+++ b/R/simulate_frailty.R
@@ -20,7 +20,13 @@
 #' @examples
 #' params <- list(baseline = 0.1, beta = 0.5, frailty_var = 0.2)
 #' X <- matrix(rnorm(20), ncol = 1)
-#' simulate_frailty_data("exponential", n = 20, params = params, X = X)
+#' sim <- simulate_frailty_data("exponential", n = 20, params = params, X = X)
+#' init <- list(baseline = 0.1, beta = 0, frailty_var = 0.2)
+#' fit <- estimate_frailty_mle(init, sim$time, sim$event, X, "exponential")
+#' \dontrun{
+#' frailty_simulation_pipeline("exponential", sims = 2, n = c(20, 40),
+#'                             true_params = params, plot = FALSE)
+#' }
 #' @export
 simulate_frailty_data <- function(baseline, n, params, X) {
   resolve_baseline <- function(baseline) {


### PR DESCRIPTION
## Summary
- Extend `simulate_frailty_data` docs with examples for simulation, estimation, and pipeline usage
- Document the full workflow in `estimate_frailty_mle` and `frailty_simulation_pipeline`

## Testing
- `R -q -e "testthat::test_dir('tests/')"` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6892897882b0832d8c1e20a9bdc6c85d