### PR TITLE
Centralize baseline hazard resolution

### DIFF
--- a/R/baseline_gompertz.R
+++ b/R/baseline_gompertz.R
@@ -1,0 +1,75 @@
+#' Gompertz baseline hazard and derivatives
+#'
+#' Provides hazard, cumulative hazard, log-likelihood, score and Hessian for a
+#' Gompertz baseline hazard. Parameter vector is `params = c(lambda, gamma)` with
+#' both parameters > 0.
+#'
+#' @param t Numeric vector of times.
+#' @param params Numeric vector `c(lambda, gamma)`.
+#'
+#' @return `h0_gompertz` and `H0_gompertz` return numeric vectors of hazard and
+#'   cumulative hazard values.
+#' @examples
+#' h0_gompertz(1:3, c(0.5, 0.1))
+#' @export
+h0_gompertz <- function(t, params) {
+  lambda <- params[1]
+  gamma <- params[2]
+  lambda * exp(gamma * t)
+}
+
+#' @rdname h0_gompertz
+#' @export
+H0_gompertz <- function(t, params) {
+  lambda <- params[1]
+  gamma <- params[2]
+  lambda / gamma * (exp(gamma * t) - 1)
+}
+
+#' Log-likelihood for Gompertz baseline
+#'
+#' @param params Numeric vector `c(lambda, gamma)`.
+#' @param times Follow-up times.
+#' @param event Event indicators (1 = event, 0 = censored).
+#'
+#' @return Numeric scalar log-likelihood.
+#' @export
+loglik_gompertz <- function(params, times, event) {
+  lambda <- params[1]
+  gamma <- params[2]
+  if (any(params <= 0)) return(-Inf)
+  h <- h0_gompertz(times, params)
+  H <- H0_gompertz(times, params)
+  sum(event * log(h) - H)
+}
+
+#' Score vector for Gompertz baseline
+#'
+#' Numerical gradient of the log-likelihood with respect to the parameters.
+#'
+#' @inheritParams loglik_gompertz
+#'
+#' @return Numeric vector of length two.
+#' @export
+score_gompertz <- function(params, times, event) {
+  if (!requireNamespace("numDeriv", quietly = TRUE)) {
+    stop("Package 'numDeriv' is required for score_gompertz")
+  }
+  numDeriv::grad(loglik_gompertz, params, times = times, event = event)
+}
+
+#' Hessian matrix for Gompertz baseline
+#'
+#' Numerical Hessian of the log-likelihood with respect to the parameters.
+#'
+#' @inheritParams loglik_gompertz
+#'
+#' @return `2 x 2` numeric matrix.
+#' @export
+hessian_gompertz <- function(params, times, event) {
+  if (!requireNamespace("numDeriv", quietly = TRUE)) {
+    stop("Package 'numDeriv' is required for hessian_gompertz")
+  }
+  numDeriv::hessian(loglik_gompertz, params, times = times, event = event)
+}
+

--- a/R/baseline_loglogistic.R
+++ b/R/baseline_loglogistic.R
@@ -1,0 +1,74 @@
+#' Log-logistic baseline hazard and derivatives
+#'
+#' Functions for a log-logistic baseline hazard. Parameter vector is
+#' `params = c(shape, scale)` with both parameters > 0.
+#'
+#' @param t Numeric vector of times.
+#' @param params Numeric vector `c(shape, scale)`.
+#'
+#' @return `h0_loglogistic` and `H0_loglogistic` return numeric vectors of hazard
+#'   and cumulative hazard values.
+#' @examples
+#' h0_loglogistic(1:3, c(2, 1))
+#' @export
+h0_loglogistic <- function(t, params) {
+  shape <- params[1]
+  scale <- params[2]
+  (shape / scale) * (t / scale)^(shape - 1) / (1 + (t / scale)^shape)
+}
+
+#' @rdname h0_loglogistic
+#' @export
+H0_loglogistic <- function(t, params) {
+  shape <- params[1]
+  scale <- params[2]
+  log(1 + (t / scale)^shape)
+}
+
+#' Log-likelihood for log-logistic baseline
+#'
+#' @param params Numeric vector `c(shape, scale)`.
+#' @param times Follow-up times.
+#' @param event Event indicators (1 = event, 0 = censored).
+#'
+#' @return Numeric scalar log-likelihood.
+#' @export
+loglik_loglogistic <- function(params, times, event) {
+  shape <- params[1]
+  scale <- params[2]
+  if (any(params <= 0)) return(-Inf)
+  h <- h0_loglogistic(times, params)
+  H <- H0_loglogistic(times, params)
+  sum(event * log(h) - H)
+}
+
+#' Score vector for log-logistic baseline
+#'
+#' Numerical gradient of the log-likelihood with respect to the parameters.
+#'
+#' @inheritParams loglik_loglogistic
+#'
+#' @return Numeric vector of length two.
+#' @export
+score_loglogistic <- function(params, times, event) {
+  if (!requireNamespace("numDeriv", quietly = TRUE)) {
+    stop("Package 'numDeriv' is required for score_loglogistic")
+  }
+  numDeriv::grad(loglik_loglogistic, params, times = times, event = event)
+}
+
+#' Hessian matrix for log-logistic baseline
+#'
+#' Numerical Hessian of the log-likelihood with respect to the parameters.
+#'
+#' @inheritParams loglik_loglogistic
+#'
+#' @return `2 x 2` numeric matrix.
+#' @export
+hessian_loglogistic <- function(params, times, event) {
+  if (!requireNamespace("numDeriv", quietly = TRUE)) {
+    stop("Package 'numDeriv' is required for hessian_loglogistic")
+  }
+  numDeriv::hessian(loglik_loglogistic, params, times = times, event = event)
+}
+

--- a/R/estimate_frailty_mle.R
+++ b/R/estimate_frailty_mle.R
@@ -26,58 +26,6 @@
 #' }
 #' @export
 estimate_frailty_mle <- function(params_init, times, event, X, baseline) {
-  resolve_baseline <- function(baseline) {
-    if (is.character(baseline)) {
-      b <- switch(tolower(baseline),
-        exponential = list(
-          param_names = "rate",
-          positive = TRUE,
-          h0 = function(t, p) rep(p[1], length(t)),
-          H0 = function(t, p) p[1] * t
-        ),
-        weibull = list(
-          param_names = c("shape", "scale"),
-          positive = c(TRUE, TRUE),
-          h0 = function(t, p) p[1] / p[2] * (t / p[2])^(p[1] - 1),
-          H0 = function(t, p) (t / p[2])^p[1]
-        ),
-        gompertz = list(
-          param_names = c("lambda", "gamma"),
-          positive = c(TRUE, TRUE),
-          h0 = function(t, p) p[1] * exp(p[2] * t),
-          H0 = function(t, p) p[1] / p[2] * (exp(p[2] * t) - 1)
-        ),
-        loglogistic = list(
-          param_names = c("shape", "scale"),
-          positive = c(TRUE, TRUE),
-          h0 = function(t, p) (p[1] / p[2]) * (t / p[2])^(p[1] - 1) /
-            (1 + (t / p[2])^p[1]),
-          H0 = function(t, p) log(1 + (t / p[2])^p[1])
-        ),
-        lognormal = list(
-          param_names = c("meanlog", "sdlog"),
-          positive = c(FALSE, TRUE),
-          h0 = function(t, p) dlnorm(t, meanlog = p[1], sdlog = p[2]) /
-            (1 - plnorm(t, meanlog = p[1], sdlog = p[2])),
-          H0 = function(t, p) -log(1 - plnorm(t, meanlog = p[1], sdlog = p[2]))
-        ),
-        stop("Unsupported baseline distribution")
-      )
-    } else if (is.list(baseline)) {
-      required <- c("h0", "H0")
-      if (!all(required %in% names(baseline))) {
-        stop("Custom baseline must provide h0 and H0 functions")
-      }
-      b <- baseline
-      b$param_names <- b$param_names %||% character(0)
-      b$positive <- b$positive %||% rep(TRUE, length(b$param_names))
-    } else {
-      stop("baseline must be a character string or list")
-    }
-    b
-  }
-  `%||%` <- function(a, b) if (!is.null(a)) a else b
-
   n <- length(times)
   if (length(event) != n) stop("times and event must have same length")
   if (!is.matrix(X) || nrow(X) != n) stop("X must be a matrix with n rows")
@@ -89,7 +37,7 @@ estimate_frailty_mle <- function(params_init, times, event, X, baseline) {
   p <- ncol(X)
   if (length(beta_init) != p) stop("beta length mismatch with columns of X")
 
-  base <- resolve_baseline(baseline)
+  base <- get_baseline_functions(baseline)
   k <- length(base$param_names)
   if (length(base_params_init) != k) stop("baseline parameter length mismatch")
 

--- a/R/frailty_simulation_pipeline.R
+++ b/R/frailty_simulation_pipeline.R
@@ -5,8 +5,8 @@
 #' draws a funnel plot of interval width against sample size.
 #'
 #' @param baseline Either a character string identifying the baseline
-#'   distribution ("exponential", "weibull" or "lognormal") or a list with
-#'   elements `h0`, `H0` and optionally `H0_inv`.
+#'   distribution ("exponential", "weibull", "gompertz", "loglogistic" or
+#'   "lognormal") or a list with elements `h0`, `H0` and optionally `H0_inv`.
 #' @param sims Number of simulation replicates.
 #' @param n Integer vector of sample sizes.
 #' @param true_params List with components `baseline` (numeric vector of true
@@ -34,61 +34,8 @@
 #' @export
 frailty_simulation_pipeline <- function(baseline, sims, n, true_params, plot = TRUE) {
   `%||%` <- function(a, b) if (!is.null(a)) a else b
-  resolve_baseline <- function(baseline) {
-    if (is.character(baseline)) {
-      switch(tolower(baseline),
-        exponential = list(
-          h0 = function(t, p) h0_exponential(t, p),
-          H0 = function(t, p) H0_exponential(t, p),
-          H0_inv = function(y, p) y / p[1],
-          param_names = "rate",
-          positive = TRUE
-        ),
-        weibull = list(
-          h0 = function(t, p) h0_weibull(t, p),
-          H0 = function(t, p) H0_weibull(t, p),
-          H0_inv = function(y, p) p[2] * y^(1 / p[1]),
-          param_names = c("shape", "scale"),
-          positive = c(TRUE, TRUE)
-        ),
-        lognormal = list(
-          h0 = function(t, p) h0_lognormal(t, p),
-          H0 = function(t, p) H0_lognormal(t, p),
-          H0_inv = function(y, p) qlnorm(1 - exp(-y), meanlog = p[1], sdlog = p[2]),
-          param_names = c("meanlog", "sdlog"),
-          positive = c(FALSE, TRUE)
-        ),
-        stop("Unsupported baseline distribution")
-      )
-    } else if (is.list(baseline)) {
-      if (length(baseline) == 1 && is.character(baseline[[1]])) {
-        return(resolve_baseline(baseline[[1]]))
-      }
-      required <- c("h0", "H0")
-      if (!all(required %in% names(baseline))) {
-        stop("Custom baseline must provide h0 and H0")
-      }
-      if (!is.function(baseline$h0) || !is.function(baseline$H0)) {
-        stop("h0 and H0 must be functions")
-      }
-      baseline$param_names <- baseline$param_names %||% character(0)
-      baseline$positive <- baseline$positive %||% rep(TRUE, length(baseline$param_names))
-      if (is.null(baseline$H0_inv)) {
-        H0_fun <- baseline$H0
-        baseline$H0_inv <- function(y, p) {
-          sapply(y, function(yy) {
-            uniroot(function(t) H0_fun(t, p) - yy,
-                    lower = 1e-10, upper = 1e6)$root
-          })
-        }
-      }
-      baseline
-    } else {
-      stop("baseline must be a character string or list")
-    }
-  }
 
-  base <- resolve_baseline(baseline)
+  base <- get_baseline_functions(baseline)
   n_vec <- n
   p <- length(true_params$beta)
   param_names <- c(base$param_names,

--- a/R/get_baseline_functions.R
+++ b/R/get_baseline_functions.R
@@ -1,0 +1,84 @@
+#' Retrieve baseline hazard functions
+#'
+#' Resolves baseline hazard functions either from a character string naming a
+#' supported distribution or from a custom list of functions.
+#'
+#' @param baseline Either a character string ("exponential", "weibull",
+#'   "gompertz", "loglogistic", "lognormal") or a list with elements `h0` and
+#'   `H0`, and optionally `H0_inv`, `param_names`, and `positive` indicating which
+#'   parameters must be positive.
+#'
+#' @return A list with components `h0`, `H0`, `H0_inv`, `param_names` and
+#'   `positive`.
+#' @examples
+#' get_baseline_functions("exponential")
+#' @export
+get_baseline_functions <- function(baseline) {
+  `%||%` <- function(a, b) if (!is.null(a)) a else b
+  if (is.character(baseline)) {
+    b <- switch(tolower(baseline),
+      exponential = list(
+        h0 = h0_exponential,
+        H0 = H0_exponential,
+        H0_inv = function(y, p) y / p[1],
+        param_names = "rate",
+        positive = TRUE
+      ),
+      weibull = list(
+        h0 = h0_weibull,
+        H0 = H0_weibull,
+        H0_inv = function(y, p) p[2] * y^(1 / p[1]),
+        param_names = c("shape", "scale"),
+        positive = c(TRUE, TRUE)
+      ),
+      gompertz = list(
+        h0 = h0_gompertz,
+        H0 = H0_gompertz,
+        H0_inv = function(y, p) log(1 + p[2] * y / p[1]) / p[2],
+        param_names = c("lambda", "gamma"),
+        positive = c(TRUE, TRUE)
+      ),
+      loglogistic = list(
+        h0 = h0_loglogistic,
+        H0 = H0_loglogistic,
+        H0_inv = function(y, p) p[2] * (exp(y) - 1)^(1 / p[1]),
+        param_names = c("shape", "scale"),
+        positive = c(TRUE, TRUE)
+      ),
+      lognormal = list(
+        h0 = h0_lognormal,
+        H0 = H0_lognormal,
+        H0_inv = function(y, p) qlnorm(1 - exp(-y), meanlog = p[1], sdlog = p[2]),
+        param_names = c("meanlog", "sdlog"),
+        positive = c(FALSE, TRUE)
+      ),
+      stop("Unsupported baseline distribution")
+    )
+  } else if (is.list(baseline)) {
+    if (length(baseline) == 1 && is.character(baseline[[1]])) {
+      return(get_baseline_functions(baseline[[1]]))
+    }
+    required <- c("h0", "H0")
+    if (!all(required %in% names(baseline))) {
+      stop("Custom baseline must provide h0 and H0 functions")
+    }
+    if (!is.function(baseline$h0) || !is.function(baseline$H0)) {
+      stop("h0 and H0 must be functions")
+    }
+    b <- baseline
+    b$param_names <- b$param_names %||% character(0)
+    b$positive <- b$positive %||% rep(TRUE, length(b$param_names))
+    if (is.null(b$H0_inv)) {
+      H0_fun <- b$H0
+      b$H0_inv <- function(y, p) {
+        sapply(y, function(yy) {
+          uniroot(function(t) H0_fun(t, p) - yy,
+                  lower = 1e-10, upper = 1e6)$root
+        })
+      }
+    }
+  } else {
+    stop("baseline must be a character string or list")
+  }
+  b
+}


### PR DESCRIPTION
## Summary
- add Gompertz and log-logistic baseline hazard helpers
- introduce `get_baseline_functions` to reuse baseline hazard definitions
- refactor estimation and simulation routines to use centralized baseline resolution

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_6893547d8ad4832db2e7e7d2b770241d