### PR TITLE
Add modular frailty simulation vignette

### DIFF
--- a/usage_examples/frailtySimulationPipeline.Rmd
+++ b/usage_examples/frailtySimulationPipeline.Rmd
@@ -1,0 +1,162 @@
+---
+title: "Frailty Model Simulation Pipeline"
+date: "`r Sys.Date()`"
+output:
+  html_document:
+    toc: true
+    toc_depth: 2
+    toc_float: true
+    theme: united
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
+# Source all helper functions
+lapply(list.files("R", full.names = TRUE), source)
+set.seed(2025)
+```
+
+## Introduction
+
+This vignette demonstrates how to simulate data, fit gamma frailty models, and evaluate confidence–interval coverage using reusable functions.
+Two baselines are considered:
+
+1. the built-in "exponential" baseline;  
+2. a custom linear hazard supplied via `h0` and `H0`.
+
+## Simulation Setup
+
+### Example 1: Exponential baseline
+
+```{r}
+params_exp <- list(
+  baseline = 0.1,           # exponential rate
+  beta = c(0.5, -0.3),      # covariate effects
+  frailty_var = 0.5,
+  censor_rate = 0.05
+)
+
+n <- 200
+X <- matrix(rnorm(n * length(params_exp$beta)),
+            ncol = length(params_exp$beta))
+
+sim_exp <- simulate_frailty_data("exponential", n, params_exp, X)
+head(data.frame(time = sim_exp$time,
+                event = sim_exp$event,
+                X1 = X[,1],
+                X2 = X[,2]))
+```
+
+### Example 2: Custom linear baseline
+
+```{r}
+custom_base <- list(
+  h0 = function(t, p) p[1] * t,
+  H0 = function(t, p) 0.5 * p[1] * t^2,
+  param_names = "lambda",
+  positive = TRUE
+)
+
+params_cust <- list(
+  baseline = 0.2,
+  beta = 0.5,
+  frailty_var = 0.5,
+  censor_rate = 0.05
+)
+
+X_cust <- matrix(rnorm(n), ncol = 1)
+sim_cust <- simulate_frailty_data(custom_base, n, params_cust, X_cust)
+head(data.frame(time = sim_cust$time,
+                event = sim_cust$event,
+                X = X_cust[,1]))
+```
+
+## Parameter Estimation
+
+### Example 1: Exponential baseline
+
+```{r}
+init_exp <- list(
+  baseline = 0.1,
+  beta = rep(0, length(params_exp$beta)),
+  frailty_var = 0.5
+)
+
+fit_exp <- estimate_frailty_mle(init_exp,
+                                sim_exp$time,
+                                sim_exp$event,
+                                X,
+                                "exponential")
+fit_exp
+```
+
+### Example 2: Custom baseline
+
+```{r}
+init_cust <- list(
+  baseline = 0.1,
+  beta = rep(0, length(params_cust$beta)),
+  frailty_var = 0.5
+)
+
+fit_cust <- estimate_frailty_mle(init_cust,
+                                 sim_cust$time,
+                                 sim_cust$event,
+                                 X_cust,
+                                 custom_base)
+fit_cust
+```
+
+## Coverage Study
+
+```{r}
+res_exp <- frailty_simulation_pipeline(
+  baseline = "exponential",
+  sims = 50,
+  n = c(100, 200),
+  true_params = params_exp,
+  plot = TRUE
+)
+
+res_cust <- frailty_simulation_pipeline(
+  baseline = custom_base,
+  sims = 50,
+  n = c(100, 200),
+  true_params = params_cust,
+  plot = TRUE
+)
+
+res_exp$coverage
+res_cust$coverage
+```
+
+The tables above show empirical coverage for each parameter across sample sizes.
+Values near the nominal 95% level indicate accurate confidence intervals.
+
+## Funnel Plot
+
+```{r}
+res_exp$plot
+res_cust$plot
+```
+
+The funnel plots display how confidence–interval width decreases as sample size grows,
+providing a quick visual diagnostic of estimator precision.
+
+## Conclusion
+
+This example illustrates a complete workflow for gamma frailty models:
+
+- Simulate data with `simulate_frailty_data()`.
+- Estimate parameters using `estimate_frailty_mle()`.
+- Run repeated simulations and generate coverage plus funnel plots using `frailty_simulation_pipeline()`.
+
+The same functions support both predefined baselines and fully custom hazard specifications.
+Users can adapt the simulation sizes, true parameters, or baseline forms as needed.
+
+### References
+
+- `frailty_simulation_pipeline()` orchestrates simulation, fitting, coverage estimation, and plotting
+- `simulate_frailty_data()` generates survival times and censoring indicators for gamma frailty models
+- `estimate_frailty_mle()` performs maximum-likelihood estimation given observed data and a baseline specification
+- `get_baseline_functions()` resolves built-in or custom baseline hazards through reusable components


### PR DESCRIPTION
## Summary
- Add `frailtySimulationPipeline.Rmd` example using modular functions for exponential and custom baselines
- Demonstrate parameter estimation, coverage study, and funnel plot via `frailty_simulation_pipeline`

## Testing
- `R -q -e "testthat::test_dir('tests/')"` *(failed: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68936dbd2d80832d9c988630663d0abf