### PR TITLE
Add Weibull frailty analysis workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ While this repository begins with standalone scripts, the long‑term goal is to
 
 - **`initialScript.R`** – A prototype script that fits parametric frailty models via maximum likelihood and returns empirical Bayes frailty estimates for a user-supplied data set.
 - **`frailtyWeibullEstimation.Rmd`** – An R Markdown notebook walking through simulation, estimation, and coverage analysis for a Gamma frailty model with a Weibull baseline.
+- **`scripts/R/legacy/analysis/`** – Modular R functions for simulating data,
+  estimating parameters, computing coverage, and visualizing results for the
+  Weibull baseline with Gamma frailty.
+- **`usage_examples/vignette_weibull.Rmd`** – Reproducible walkthrough sourcing
+  the analysis scripts and demonstrating the full Weibull frailty workflow.
 - **`LICENSE`** – MIT License.
 
 ## Requirements
@@ -28,6 +33,10 @@ install.packages(c("survival", "tidyverse", "parfm", "kableExtra", "ggplot2"))
 1. Edit `initialScript.R` to point to your own CSV file with survival data.
 2. Source the script or run it line by line in R to inspect the fitted parameters and frailty estimates.
 3. Open `frailtyWeibullEstimation.Rmd` in RStudio (or a similar environment) and knit it to HTML to reproduce the simulation and coverage study.
+4. Alternatively, source the functions under `scripts/R/legacy/analysis/` and
+   run `usage_examples/vignette_weibull.Rmd` to explore the modular Weibull
+   frailty workflow including simulation, estimation, coverage studies, and
+   plotting.
 
 Example data are not included, so you will need to supply your own data set to reproduce the analyses.
 

--- a/scripts/R/legacy/analysis/baseline_weibull.R
+++ b/scripts/R/legacy/analysis/baseline_weibull.R
@@ -1,0 +1,27 @@
+#' Weibull baseline hazard function
+#'
+#' Computes the baseline hazard for a Weibull distribution.
+#'
+#' @param t Numeric vector of times.
+#' @param shape Weibull shape parameter (>0).
+#' @param scale Weibull scale parameter (>0).
+#'
+#' @return Numeric vector of baseline hazards evaluated at `t`.
+#' @export
+h0_weibull <- function(t, shape, scale) {
+  (shape / scale) * (t / scale)^(shape - 1)
+}
+
+#' Weibull cumulative baseline hazard function
+#'
+#' Computes the cumulative baseline hazard for a Weibull distribution.
+#'
+#' @param t Numeric vector of times.
+#' @param shape Weibull shape parameter (>0).
+#' @param scale Weibull scale parameter (>0).
+#'
+#' @return Numeric vector of cumulative baseline hazards evaluated at `t`.
+#' @export
+H0_weibull <- function(t, shape, scale) {
+  (t / scale)^shape
+}

--- a/scripts/R/legacy/analysis/coverage_study.R
+++ b/scripts/R/legacy/analysis/coverage_study.R
@@ -1,0 +1,65 @@
+#' Coverage study for Weibull Gamma frailty model
+#'
+#' Conducts a coverage study for parameter estimates of the Weibull
+#' baseline with Gamma frailty for a fixed sample size.
+#'
+#' @param n Sample size.
+#' @param shape True Weibull shape parameter.
+#' @param scale True Weibull scale parameter.
+#' @param theta True frailty variance.
+#' @param nsim Number of simulation replicates.
+#' @param conf_level Confidence level for intervals.
+#' @param censor_rate Rate of exponential censoring. Use 0 for none.
+#'
+#' @return A list with elements `coverage` and `mean_ci_width` (named
+#'   vectors for parameters `shape`, `scale`, `theta`).
+#' @export
+coverage_study <- function(n, shape, scale, theta, nsim = 100,
+                           conf_level = 0.95, censor_rate = 0) {
+  z <- stats::qnorm(1 - (1 - conf_level) / 2)
+  cover_counts <- c(shape = 0, scale = 0, theta = 0)
+  width_sums <- c(shape = 0, scale = 0, theta = 0)
+  truth <- c(shape = shape, scale = scale, theta = theta)
+
+  for (i in seq_len(nsim)) {
+    dat <- simulate_frailty(n, shape, scale, theta, censor_rate)
+    fit <- estimate_frailty_mle(dat)
+    est <- fit$coefficients
+    se <- fit$se
+    lower <- est - z * se
+    upper <- est + z * se
+    cover_counts <- cover_counts + (lower <= truth & upper >= truth)
+    width_sums <- width_sums + (upper - lower)
+  }
+
+  list(
+    coverage = cover_counts / nsim,
+    mean_ci_width = width_sums / nsim
+  )
+}
+
+#' Coverage study over multiple sample sizes
+#'
+#' Repeats [coverage_study()] over a vector of sample sizes.
+#'
+#' @param sample_sizes Numeric vector of sample sizes.
+#' @inheritParams coverage_study
+#'
+#' @return A data frame with columns `n`, `parameter`, `coverage`, and
+#'   `mean_ci_width`.
+#' @export
+coverage_study_multi <- function(sample_sizes, shape, scale, theta,
+                                 nsim = 100, conf_level = 0.95,
+                                 censor_rate = 0) {
+  res <- lapply(sample_sizes, function(n) {
+    out <- coverage_study(n, shape, scale, theta, nsim, conf_level,
+                          censor_rate)
+    data.frame(
+      n = n,
+      parameter = names(out$coverage),
+      coverage = as.numeric(out$coverage),
+      mean_ci_width = as.numeric(out$mean_ci_width)
+    )
+  })
+  do.call(rbind, res)
+}

--- a/scripts/R/legacy/analysis/estimate_frailty_mle.R
+++ b/scripts/R/legacy/analysis/estimate_frailty_mle.R
@@ -1,0 +1,41 @@
+#' Maximum likelihood estimation for Weibull baseline with Gamma frailty
+#'
+#' Estimates the Weibull shape and scale parameters and the Gamma frailty
+#' variance using maximum likelihood.
+#'
+#' @param data A data frame with columns `time` and `event` as produced by
+#'   [simulate_frailty()].
+#' @param start Optional named vector of starting values on the natural
+#'   scale for `shape`, `scale`, and `theta`. Defaults are 1.
+#'
+#' @return A list containing parameter estimates (`coefficients`),
+#'   standard errors (`se`), the observed information matrix (`vcov`), and
+#'   the maximized log-likelihood (`loglik`).
+#' @export
+estimate_frailty_mle <- function(data, start = c(shape = 1, scale = 1, theta = 0.5)) {
+  neg_loglik <- function(par) {
+    shape <- exp(par[1])
+    scale <- exp(par[2])
+    theta <- exp(par[3])
+
+    H <- (data$time / scale)^shape
+    h <- (shape / scale) * (data$time / scale)^(shape - 1)
+
+    loglik <- data$event * (log(h) - (1/theta + 1) * log1p(theta * H)) +
+      (1 - data$event) * (-(1/theta) * log1p(theta * H))
+    -sum(loglik)
+  }
+
+  fit <- stats::optim(log(start), neg_loglik, hessian = TRUE)
+  est <- exp(fit$par)
+  vcov <- solve(fit$hessian)
+  se <- sqrt(diag(vcov)) * est
+  loglik <- -fit$value
+
+  list(
+    coefficients = stats::setNames(est, c("shape", "scale", "theta")),
+    se = stats::setNames(se, c("shape", "scale", "theta")),
+    vcov = vcov,
+    loglik = loglik
+  )
+}

--- a/scripts/R/legacy/analysis/funnel_plot.R
+++ b/scripts/R/legacy/analysis/funnel_plot.R
@@ -1,0 +1,24 @@
+#' Funnel plot of confidence interval widths by sample size
+#'
+#' Produces a plot of mean confidence interval widths versus sample size
+#' from the results of [coverage_study_multi()].
+#'
+#' @param coverage_results Data frame returned by
+#'   [coverage_study_multi()].
+#'
+#' @return A `ggplot2` object visualizing mean CI width against sample
+#'   size, faceted by parameter.
+#' @export
+funnel_plot <- function(coverage_results) {
+  if (!requireNamespace("ggplot2", quietly = TRUE)) {
+    stop("Package 'ggplot2' is required for funnel_plot().")
+  }
+
+  ggplot2::ggplot(coverage_results, ggplot2::aes(x = n, y = mean_ci_width)) +
+    ggplot2::geom_point() +
+    ggplot2::geom_line() +
+    ggplot2::facet_wrap(~parameter, scales = "free_y") +
+    ggplot2::labs(x = "Sample size", y = "Mean CI width",
+                  title = "Funnel plot of CI width by sample size") +
+    ggplot2::theme_minimal()
+}

--- a/scripts/R/legacy/analysis/simulate_frailty.R
+++ b/scripts/R/legacy/analysis/simulate_frailty.R
@@ -1,0 +1,32 @@
+#' Simulate survival times with Gamma frailty and Weibull baseline
+#'
+#' Generates survival times under a Weibull baseline hazard with
+#' individual-level Gamma frailty and optional exponential censoring.
+#'
+#' @param n Number of individuals to simulate.
+#' @param shape Weibull shape parameter.
+#' @param scale Weibull scale parameter.
+#' @param theta Variance of the Gamma frailty distribution. Frailties are
+#'   distributed as `Gamma(1/theta, 1/theta)` giving mean 1 and variance theta.
+#' @param censor_rate Rate parameter of the exponential censoring
+#'   distribution. Use 0 for no censoring.
+#'
+#' @return A data frame with columns `time`, `event` (1 = observed event,
+#'   0 = censored) and `frailty` (individual frailty values).
+#' @export
+simulate_frailty <- function(n, shape, scale, theta, censor_rate = 0) {
+  w <- rgamma(n, shape = 1/theta, rate = 1/theta)
+  u <- runif(n)
+  t <- scale * (-log(u) / w)^(1 / shape)
+
+  if (censor_rate > 0) {
+    c <- rexp(n, rate = censor_rate)
+    event <- as.integer(t <= c)
+    time <- pmin(t, c)
+  } else {
+    event <- rep(1L, n)
+    time <- t
+  }
+
+  data.frame(time = time, event = event, frailty = w)
+}

--- a/scripts/R/legacy/analysis/wrapper_pipeline.R
+++ b/scripts/R/legacy/analysis/wrapper_pipeline.R
@@ -1,0 +1,32 @@
+#' Frailty simulation pipeline for Weibull baseline
+#'
+#' Runs a complete simulation pipeline: simulate one data set,
+#' estimate parameters, perform coverage studies for one or more
+#' sample sizes, and produce a funnel plot of confidence interval widths.
+#'
+#' @param shape True Weibull shape parameter.
+#' @param scale True Weibull scale parameter.
+#' @param theta True frailty variance.
+#' @param nsim Number of simulations for coverage studies.
+#' @param sample_sizes Integer vector of sample sizes to study. The first
+#'   element is used for the example simulation and estimation output.
+#' @param conf_level Confidence level for intervals.
+#' @param censor_rate Rate for exponential censoring used in simulation.
+#'
+#' @return A list with elements `simulation` (last simulated data set),
+#'   `fit` (MLE results), `coverage` (data frame of coverage results), and
+#'   `funnel_plot` (ggplot object).
+#' @export
+frailty_simulation_pipeline_weibull <- function(shape, scale, theta,
+                                               nsim = 100,
+                                               sample_sizes,
+                                               conf_level = 0.95,
+                                               censor_rate = 0) {
+  sim <- simulate_frailty(sample_sizes[1], shape, scale, theta, censor_rate)
+  fit <- estimate_frailty_mle(sim)
+  coverage <- coverage_study_multi(sample_sizes, shape, scale, theta,
+                                   nsim, conf_level, censor_rate)
+  plot <- funnel_plot(coverage)
+
+  list(simulation = sim, fit = fit, coverage = coverage, funnel_plot = plot)
+}

--- a/usage_examples/vignette_weibull.Rmd
+++ b/usage_examples/vignette_weibull.Rmd
@@ -1,0 +1,53 @@
+---
+title: "Weibull Frailty Workflow"
+output: html_document
+---
+
+```{r setup}
+source("../scripts/R/legacy/analysis/baseline_weibull.R")
+source("../scripts/R/legacy/analysis/simulate_frailty.R")
+source("../scripts/R/legacy/analysis/estimate_frailty_mle.R")
+source("../scripts/R/legacy/analysis/coverage_study.R")
+source("../scripts/R/legacy/analysis/funnel_plot.R")
+source("../scripts/R/legacy/analysis/wrapper_pipeline.R")
+```
+
+## Simulating data
+
+```{r simulation}
+set.seed(123)
+sim <- simulate_frailty(n = 100, shape = 1.2, scale = 1, theta = 0.5)
+head(sim)
+```
+
+## Estimating parameters
+
+```{r estimation}
+fit <- estimate_frailty_mle(sim)
+fit
+```
+
+## Coverage study
+
+```{r coverage}
+cover <- coverage_study_multi(sample_sizes = c(50, 100, 200),
+                              shape = 1.2, scale = 1, theta = 0.5,
+                              nsim = 50)
+cover
+```
+
+## Funnel plot
+
+```{r funnel, fig.height=4, fig.width=6}
+plot <- funnel_plot(cover)
+plot
+```
+
+## Wrapper pipeline
+
+```{r pipeline}
+pipeline <- frailty_simulation_pipeline_weibull(shape = 1.2, scale = 1,
+                                                theta = 0.5, nsim = 50,
+                                                sample_sizes = c(100, 200, 400))
+str(pipeline, max.level = 1)
+```


### PR DESCRIPTION
## Summary
- implement Weibull baseline hazard and cumulative hazard helpers
- add simulation, MLE estimation, coverage analysis, and plotting functions for Gamma frailty
- include vignette and README instructions for the new Weibull frailty workflow

## Testing
- `pytest`
- `R -q -e "testthat::test_dir('tests/')"` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6893773e777c832d8187e4631ed12618