### PR TITLE
Add modular Weibull frailty analysis notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ While this repository begins with standalone scripts, the long‑term goal is to
   Weibull baseline with Gamma frailty.
 - **`usage_examples/vignette_weibull.Rmd`** – Reproducible walkthrough sourcing
   the analysis scripts and demonstrating the full Weibull frailty workflow.
+- **`usage_examples/frailty_weibull_analysis.Rmd`** – Notebook showcasing the
+  modular functions for simulation, estimation, coverage studies, and the
+  wrapper pipeline.
 - **`LICENSE`** – MIT License.
 
 ## Requirements
@@ -37,6 +40,8 @@ install.packages(c("survival", "tidyverse", "parfm", "kableExtra", "ggplot2"))
    run `usage_examples/vignette_weibull.Rmd` to explore the modular Weibull
    frailty workflow including simulation, estimation, coverage studies, and
    plotting.
+5. For a concise end-to-end demonstration of these functions, knit
+   `usage_examples/frailty_weibull_analysis.Rmd`.
 
 Example data are not included, so you will need to supply your own data set to reproduce the analyses.
 

--- a/usage_examples/frailty_weibull_analysis.Rmd
+++ b/usage_examples/frailty_weibull_analysis.Rmd
@@ -1,0 +1,58 @@
+---
+title: "Frailty Model Analysis via Modular Functions"
+output:
+  html_document:
+    toc: true
+    toc_depth: 2
+    toc_float: true
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE, warning = FALSE, message = FALSE)
+source("../scripts/R/legacy/analysis/baseline_weibull.R")
+source("../scripts/R/legacy/analysis/simulate_frailty.R")
+source("../scripts/R/legacy/analysis/estimate_frailty_mle.R")
+source("../scripts/R/legacy/analysis/coverage_study.R")
+source("../scripts/R/legacy/analysis/funnel_plot.R")
+source("../scripts/R/legacy/analysis/wrapper_pipeline.R")
+```
+
+## 1. Simulate Weibull Survival Times
+
+```{r simulate}
+set.seed(2025)
+sim_data <- simulate_frailty(n = 200, shape = 1.4, scale = 1, theta = 0.6)
+head(sim_data)
+```
+
+## 2. Estimate Frailty Model Parameters
+
+```{r estimate}
+fit <- estimate_frailty_mle(sim_data)
+fit
+```
+
+## 3. Coverage Study Across Sample Sizes
+
+```{r coverage}
+cover_res <- coverage_study_multi(sample_sizes = c(50, 100, 200),
+                                  shape = 1.4, scale = 1, theta = 0.6,
+                                  nsim = 30)
+cover_res
+```
+
+## 4. Visualize Confidence Interval Widths
+
+```{r funnel_plot, fig.width=6, fig.height=4}
+funnel_plot(cover_res)
+```
+
+## 5. End-to-End Pipeline
+
+```{r pipeline}
+pipe <- frailty_simulation_pipeline_weibull(shape = 1.4, scale = 1,
+                                            theta = 0.6, nsim = 30,
+                                            sample_sizes = c(100, 200, 400))
+str(pipe, max.level = 1)
+```
+


### PR DESCRIPTION
## Summary
- add `frailty_weibull_analysis.Rmd` demonstrating frailty simulation, estimation, coverage, and pipeline via modular functions
- document new usage example in README

## Testing
- `pytest`
- `R -q -e "testthat::test_dir('tests/')"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_689cd4b5ceb0832d99b2de36566a5ec3